### PR TITLE
PSR2 Style Fixes

### DIFF
--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -66,7 +66,7 @@ class UserController extends Controller
     {
         $validation = $this->validator->make($data, $rules);
 
-        if($validation->fails()) {
+        if ($validation->fails()) {
             return response($validation->errors()->toArray(), 400);
         }
 

--- a/app/Http/Requests/StoreArtist.php
+++ b/app/Http/Requests/StoreArtist.php
@@ -31,7 +31,7 @@ class StoreArtist extends FormRequest
             'territory' => 'max:255',
             'country_code' => 'exists:countries,code',
             'official_url' => 'url',
-            'profile_url' => 'max:64', // TODO This requires further validation, to prevent tomfoolery, profanity, etc...
+            'profile_url' => 'max:64', // TODO This requires further validation, to prevent tomfoolery, profanity, etc..
         ];
     }
 }

--- a/app/Observers/AlbumObserver.php
+++ b/app/Observers/AlbumObserver.php
@@ -56,7 +56,6 @@ class AlbumObserver
      */
     public function deleted(Album $album)
     {
-
     }
 
     /**

--- a/app/Repositories/ArtistRepository.php
+++ b/app/Repositories/ArtistRepository.php
@@ -4,11 +4,11 @@ namespace App\Repositories;
 
 use App\Artist;
 use App\Contracts\ArtistRepositoryInterface;
-use App\Traits\isProfilable;
+use App\Traits\IsProfilable;
 
 class ArtistRepository extends BaseRepository implements ArtistRepositoryInterface
 {
-    use isProfilable;
+    use IsProfilable;
 
     /**
      * @var string $class

--- a/app/Repositories/LabelRepository.php
+++ b/app/Repositories/LabelRepository.php
@@ -4,11 +4,11 @@ namespace App\Repositories;
 
 use App\Label;
 use App\Contracts\LabelRepositoryInterface;
-use App\Traits\isProfilable;
+use App\Traits\IsProfilable;
 
 class LabelRepository extends BaseRepository implements LabelRepositoryInterface
 {
-    use isProfilable;
+    use IsProfilable;
 
     /**
      * @var string $class

--- a/app/Traits/IsProfilable.php
+++ b/app/Traits/IsProfilable.php
@@ -4,11 +4,10 @@ namespace App\Traits;
 
 use App\Contracts\ProfileRepositoryInterface;
 
-trait isProfilable
+trait IsProfilable
 {
     public function profilable()
     {
         return resolve(ProfileRepositoryInterface::class);
     }
-
 }

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -31,12 +31,12 @@ return [
 
     /*
      * Which headers to use to detect proxy related data (For, Host, Proto, Port)
-     * 
+     *
      * Options include:
-     * 
+     *
      * - Illuminate\Http\Request::HEADER_X_FORWARDED_ALL (use all x-forwarded-* headers to establish trust)
      * - Illuminate\Http\Request::HEADER_FORWARDED (use the FORWARDED header to establish trust)
-     * 
+     *
      * @link https://symfony.com/doc/current/deployment/proxies.html
      */
     'headers' => Illuminate\Http\Request::HEADER_X_FORWARDED_ALL,

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -27,6 +27,7 @@ parameters:
         - /^storage\/(.*)/
         - /^public\/(.*)/
         - /^resources\/(.*)/
+        - /^database\/(.*)/
       sniffs: []
       triggered_by: [php]
     git_blacklist:

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,7 +21,7 @@ abstract class TestCase extends BaseTestCase
         try {
             $class = new ReflectionClass($class);
             return $class->isInstantiable();
-        } catch(\ReflectionException $e) {
+        } catch (\ReflectionException $e) {
             throw new $e;
         }
     }


### PR DESCRIPTION
Ran an automated fix on these files

Note the command used for this was
`vendor/bin/phpcbf --standard=PSR2 ./`

***Note that I had to revert changes made in the `database` directory before committing due to them failing a namespace sniff.***

This PR aslo tries to address ignoring the `database` directory to avoid the above error, however its not working as expected.

```
If a file in this directory is staged to be committed it will be scanned 
(regardless of the ignore pattern being added) and will fail due to the 
namespace sniff. I'm not really sure at this time how to fix/avoid this. 
To me it seems like it should behave as we would expect it to. Possible bug ?
```