### PR TITLE
fix: Remove duplicate route definitions

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -31,18 +31,6 @@ Route::namespace('Api')->group(function () {
         Route::post('/create', 'UserController@store')->name('user.store');
         Route::put('/{id}', 'UserController@update')->name('user.update');
         Route::delete('/{id}', 'UserController@destroy')->name('user.destroy');
-        Route::post('/{id}/password', 'UserController@updatePassword')->name('password.update');
-    });
-
-    /*
-     * Users
-     */
-    Route::prefix('users')->group(function () {
-        Route::get('/', 'UserController@all')->name('user.index');
-        Route::get('/{id}', 'UserController@show')->name('user.show');
-        Route::post('/create', 'UserController@store')->name('user.store');
-        Route::put('/{id}', 'UserController@update')->name('user.update');
-        Route::delete('/{id}', 'UserController@destroy')->name('user.destroy');
     });
 
     /*


### PR DESCRIPTION
It seems like these resulted during conflict resolution during merge
(probably my doing)