### PR TITLE
Api Routes

### DIFF
--- a/app/Providers/ApiRouteServiceProvider.php
+++ b/app/Providers/ApiRouteServiceProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+
+class ApiRouteServiceProvider extends ServiceProvider
+{
+    protected $namespace = 'App\Http\Controllers\Api';
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        parent::boot();
+
+        //
+    }
+
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
+
+    /**
+     * Map all Api Routes here
+     *
+     */
+    public function map()
+    {
+        $this->mapRoutes('users', 'UserController');
+        $this->mapRoutes('artists', 'ArtistController');
+        $this->mapRoutes('albums', 'AlbumController');
+        $this->mapRoutes('flacfiles', 'FlacFileController');
+        $this->mapRoutes('skus', 'SkuController');
+        $this->mapRoutes('songs', 'SongController');
+        // ...
+    }
+
+    private function mapRoutes($prefix, $controller)
+    {
+        Route::prefix('api')
+            ->middleware('api')
+            ->namespace($this->namespace)
+            ->group(function () use ($controller, $prefix) {
+                Route::prefix($prefix)->group(function () use ($controller, $prefix) {
+                    Route::get('/', "$controller@all")->name("$prefix.index");
+                    Route::get('/{id}', "$controller@show")->name("$prefix.show");
+                    Route::post('/create', "$controller@store")->name("$prefix.store");
+                    Route::put('/{id}', "$controller@update")->name("$prefix.update");
+                    Route::delete('/{id}', "$controller@destroy")->name("$prefix.destroy");
+                });
+            });
+    }
+}

--- a/app/Providers/ApiRouteServiceProvider.php
+++ b/app/Providers/ApiRouteServiceProvider.php
@@ -46,18 +46,22 @@ class ApiRouteServiceProvider extends ServiceProvider
         // ...
     }
 
-    private function mapRoutes($prefix, $controller)
+    private function mapRoutes($prefix, $controller, \Closure $closure = null)
     {
         Route::prefix('api')
             ->middleware('api')
             ->namespace($this->namespace)
-            ->group(function () use ($controller, $prefix) {
-                Route::prefix($prefix)->group(function () use ($controller, $prefix) {
+            ->group(function () use ($controller, $prefix, $closure) {
+                Route::prefix($prefix)->group(function () use ($controller, $prefix, $closure) {
                     Route::get('/', "$controller@all")->name("$prefix.index");
                     Route::get('/{id}', "$controller@show")->name("$prefix.show");
                     Route::post('/create', "$controller@store")->name("$prefix.store");
                     Route::put('/{id}', "$controller@update")->name("$prefix.update");
                     Route::delete('/{id}', "$controller@destroy")->name("$prefix.destroy");
+
+                    if ($closure !== null) {
+                        $closure();
+                    }
                 });
             });
     }

--- a/config/app.php
+++ b/config/app.php
@@ -159,6 +159,7 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        App\Providers\ApiRouteServiceProvider::class,
 
         Cartalyst\Sentinel\Laravel\SentinelServiceProvider::class,
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,46 +1,12 @@
 <?php
 
-use Illuminate\Http\Request;
-
-use App\Artist;
-use App\Http\Resources\CatalogResource;
-
 /*
 |--------------------------------------------------------------------------
 | API Routes
 |--------------------------------------------------------------------------
 |
-| Here is where you can register API routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| is assigned the "api" middleware group. Enjoy building your API!
+| ATTENTION:
+|
+|   All API routes need to be registered in the app/Providers/ApiRouteServiceProvider.php
 |
 */
-
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
-});
-
-Route::namespace('Api')->group(function () {
-
-    /*
-     * Users
-     */
-    Route::prefix('users')->group(function () {
-        Route::get('/', 'UserController@all')->name('user.index');
-        Route::get('/{id}', 'UserController@show')->name('user.show');
-        Route::post('/create', 'UserController@store')->name('user.store');
-        Route::put('/{id}', 'UserController@update')->name('user.update');
-        Route::delete('/{id}', 'UserController@destroy')->name('user.destroy');
-    });
-
-    /*
-     * Artists
-     */
-    Route::prefix('artists')->group(function () {
-        Route::get('/', 'ArtistController@index')->name('artist.index');
-        Route::get('/{id}', 'ArtistController@show')->name('artist.show');
-        Route::post('/create', 'ArtistController@store')->name('artist.store');
-        Route::put('/{id}', 'ArtistController@update')->name('artist.update');
-        Route::delete('/{id}', 'ArtistController@destroy')->name('artist.destroy');
-    });
-});

--- a/tests/Feature/Controllers/ArtistControllerTest.php
+++ b/tests/Feature/Controllers/ArtistControllerTest.php
@@ -75,7 +75,7 @@ class ArtistControllerTest extends ControllerTestCase
     {
         $this->spawnArtist();
 
-        $this->json('GET', route('artist.index'))
+        $this->json('GET', route('artists.index'))
             ->assertStatus(200)
             ->assertJsonStructure([
                 'data' => [
@@ -86,7 +86,7 @@ class ArtistControllerTest extends ControllerTestCase
 
     public function test_store_withValidInputs_returnsOneJsonObject()
     {
-        $this->json('POST', route('artist.store'), $this->getAllInputsInValidState())
+        $this->json('POST', route('artists.store'), $this->getAllInputsInValidState())
             ->assertStatus(201)
             ->assertJsonStructure([
                 'data' => $this->getJsonStructure()
@@ -95,7 +95,7 @@ class ArtistControllerTest extends ControllerTestCase
 
     public function test_store_withInvalidInputs_returnsErrorMessage()
     {
-        $this->json('POST', route('artist.store'), $this->getInputsInInvalidState())
+        $this->json('POST', route('artists.store'), $this->getInputsInInvalidState())
             ->assertStatus(422)
             ->assertJsonStructure([
                 'message',
@@ -107,7 +107,7 @@ class ArtistControllerTest extends ControllerTestCase
     {
         $artist = $this->spawnArtist();
 
-        $this->json('GET', route('artist.show', ['id' => $artist->id]))
+        $this->json('GET', route('artists.show', ['id' => $artist->id]))
             ->assertStatus(200)
             ->assertJsonStructure([
                 'data' => $this->getJsonStructure()
@@ -122,7 +122,7 @@ class ArtistControllerTest extends ControllerTestCase
 
         $inputs['alt_moniker'] = 'Back in the Garage';
 
-        $this->json('PUT', route('artist.update', ['id' => $artist->id]), $inputs)
+        $this->json('PUT', route('artists.update', ['id' => $artist->id]), $inputs)
             ->assertStatus(200)
             ->assertJson([
                 'data' => [
@@ -139,7 +139,7 @@ class ArtistControllerTest extends ControllerTestCase
     {
         $artist = $this->spawnArtist();
 
-        $this->json('PUT', route('artist.update', ['id' => $artist->id]), $this->getInputsInInvalidState())
+        $this->json('PUT', route('artists.update', ['id' => $artist->id]), $this->getInputsInInvalidState())
             ->assertStatus(422)
             ->assertJsonStructure([
                 'message',

--- a/tests/Feature/Controllers/UserControllerTest.php
+++ b/tests/Feature/Controllers/UserControllerTest.php
@@ -111,7 +111,7 @@ class UserControllerTest extends ControllerTestCase
     {
         $this->spawnUser();
 
-        $this->json('GET', route('user.index'))
+        $this->json('GET', route('users.index'))
             ->assertStatus(200)
             ->assertJsonStructure([
                 'data' => [
@@ -122,7 +122,7 @@ class UserControllerTest extends ControllerTestCase
 
     public function test_store_withValidInputs_returnsOneJsonObject()
     {
-        $this->json('POST', route('user.store'), $this->getAllInputsInValidState())
+        $this->json('POST', route('users.store'), $this->getAllInputsInValidState())
             ->assertStatus(201)
             ->assertJsonStructure([
                 'data' => $this->getJsonStructure()
@@ -131,7 +131,7 @@ class UserControllerTest extends ControllerTestCase
 
     public function test_store_withInvalidInputs_returnsErrorMessage()
     {
-        $this->json('POST', route('user.store'), $this->getInputsInInvalidState())
+        $this->json('POST', route('users.store'), $this->getInputsInInvalidState())
             ->assertStatus(422)
             ->assertJsonStructure([
                 'message',
@@ -143,7 +143,7 @@ class UserControllerTest extends ControllerTestCase
     {
         $user = $this->spawnUser();
 
-        $this->json('GET', route('user.show', ['id' => $user->id]))
+        $this->json('GET', route('users.show', ['id' => $user->id]))
             ->assertStatus(200)
             ->assertJsonStructure([
                 'data' => $this->getJsonStructure()
@@ -158,7 +158,7 @@ class UserControllerTest extends ControllerTestCase
 
         $inputs['username'] = 'FoobiusBazius';
 
-        $this->json('PUT', route('user.update', ['id' => $user->id]), $inputs)
+        $this->json('PUT', route('users.update', ['id' => $user->id]), $inputs)
             ->assertStatus(200)
             ->assertJson([
                 'data' => [
@@ -175,7 +175,7 @@ class UserControllerTest extends ControllerTestCase
     {
         $user = $this->spawnUser();
 
-        $this->json('PUT', route('user.update', ['id' => $user->id]), $this->getInputsInInvalidState())
+        $this->json('PUT', route('users.update', ['id' => $user->id]), $this->getInputsInInvalidState())
             ->assertStatus(422)
             ->assertJsonStructure([
                 'message',
@@ -187,7 +187,7 @@ class UserControllerTest extends ControllerTestCase
     {
         $inputs = $this->getAllInputsInValidState();
 
-        $this->json('POST', route('user.store'), $inputs)
+        $this->json('POST', route('users.store'), $inputs)
             ->assertStatus(201)
             ->assertJsonStructure([
                 'data' => $this->getJsonStructure()
@@ -204,7 +204,7 @@ class UserControllerTest extends ControllerTestCase
 
         $inputs = ['password' => 'secretsauce'];
 
-        $this->json('PUT', route('user.update', ['id' => $user->id]), $inputs)
+        $this->json('PUT', route('users.update', ['id' => $user->id]), $inputs)
             ->assertStatus(200)
             ->assertJsonStructure([
                 'data' => $this->getJsonStructure()


### PR DESCRIPTION
***Only Merge AFTER PR #71***

*Will need to force Travis to rebuild after the above PR has been merged. 
Tests are expected to fail until then!*

Most of the routes are duplicating most of the logic, we can
dynamically build up the routes using this method. Mapping new routes
are now easy, quick and stays consistent in structure.

This makes the `routes/api.php` obsolete, but stays to redirect devs to
the right place.

*Note: Auth (passport) middleware will have to be added later*