### PR TITLE
Add additional routes through method chaining with new obj

### DIFF
--- a/app/Providers/ApiRouteServiceProvider.php
+++ b/app/Providers/ApiRouteServiceProvider.php
@@ -2,12 +2,11 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\Route;
+use App\Services\ApiRoute;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 
 class ApiRouteServiceProvider extends ServiceProvider
 {
-    protected $namespace = 'App\Http\Controllers\Api';
 
     /**
      * Bootstrap services.
@@ -46,23 +45,10 @@ class ApiRouteServiceProvider extends ServiceProvider
         // ...
     }
 
-    private function mapRoutes($prefix, $controller, \Closure $closure = null)
+    private function mapRoutes($prefix, $controller)
     {
-        Route::prefix('api')
-            ->middleware('api')
-            ->namespace($this->namespace)
-            ->group(function () use ($controller, $prefix, $closure) {
-                Route::prefix($prefix)->group(function () use ($controller, $prefix, $closure) {
-                    Route::get('/', "$controller@all")->name("$prefix.index");
-                    Route::get('/{id}', "$controller@show")->name("$prefix.show");
-                    Route::post('/create', "$controller@store")->name("$prefix.store");
-                    Route::put('/{id}', "$controller@update")->name("$prefix.update");
-                    Route::delete('/{id}', "$controller@destroy")->name("$prefix.destroy");
-
-                    if ($closure !== null) {
-                        $closure();
-                    }
-                });
-            });
+        $dto = new ApiRoute($prefix, $controller);
+        $dto->mapDefaultRoutes();
+        return $dto;
     }
 }

--- a/app/Services/ApiRoute.php
+++ b/app/Services/ApiRoute.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Route;
+
+class ApiRoute
+{
+    /**
+     * @var string $namespace
+     */
+    protected $namespace = 'App\Http\Controllers\Api';
+
+    /**
+     * @var $prefix
+     */
+    private $prefix;
+
+    /**
+     * @var $controller
+     */
+    private $controller;
+
+
+    public function __construct($prefix, $controller)
+    {
+        $this->prefix = $prefix;
+        $this->controller = $controller;
+    }
+
+    public function mapDefaultRoutes()
+    {
+        $controller = $this->controller;
+        $prefix = $this->prefix;
+
+        Route::prefix('api')
+            ->middleware('-')
+            ->namespace($this->namespace)
+            ->group(function () use ($controller, $prefix) {
+                Route::prefix($this->prefix)->group(function () use ($controller, $prefix) {
+                    Route::get('/', "$controller@all")->name("$prefix.index");
+                    Route::get('/{id}', "$controller@show")->name("$prefix.show");
+                    Route::post('/create', "$controller@store")->name("$prefix.store");
+                    Route::put('/{id}', "$controller@update")->name("$prefix.update");
+                    Route::delete('/{id}', "$controller@destroy")->name("$prefix.destroy");
+                });
+            });
+
+        return $this;
+    }
+
+    public function mapAdditionalRoute($uri, $controllerMethod, $httpMethod = 'get')
+    {
+        $httpMethod = strtolower($httpMethod);
+        $controllerMethod = snake_case($controllerMethod);
+
+        $controller = $this->controller;
+        $prefix = $this->prefix;
+
+        Route::$httpMethod($uri, "$controller@$controllerMethod")->name("$prefix.$controllerMethod");
+
+        return $this;
+    }
+}


### PR DESCRIPTION
In some cases it makes sense that some controllers might need additional
routes, this gives the ability to add them in a closure.

So instead of using the closure for defining additional routes ...

I propose a more elegant solution:
```php
$this->mapRoutes('flacfiles', 'FlacFileController');
$this->mapRoutes('skus', 'SkuController');

$this->mapRoutes('songs', 'SongController')
     ->mapAdditionalRoute('/whatever', 'method') // default `get` route
      ->mapAdditionalRoute('/whatever/{id}', 'someMethod', 'post');
// ...
```