### PR TITLE
Abstract ApiController

### DIFF
--- a/app/Console/Commands/MakeApiControllerCommand.php
+++ b/app/Console/Commands/MakeApiControllerCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Filesystem\Filesystem;
+
+class MakeApiControllerCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'make:api:controller';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generates a new Api Controller';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Controller';
+
+    /**
+     * @var Filesystem
+     */
+    private $file;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param Filesystem $file
+     */
+    public function __construct(Filesystem $file)
+    {
+        parent::__construct($file);
+
+        $this->file = $file;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Http\Controllers\Api';
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return resource_path('stubs/apicontroller.stub');
+    }
+}

--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+abstract class ApiController extends Controller
+{
+    /**
+     * @var $repository
+     */
+    protected $repository;
+
+    /**
+     * Should return the <RepositoryInterface>::class
+     *
+     * @return string
+     */
+    abstract public function repository();
+
+    /**
+     * @var $resource
+     */
+    protected $resource;
+
+    /**
+     * Should return the <Resource>::class
+     *
+     * @return string
+     */
+    abstract public function resource();
+
+    /**
+     * These rules are shared between both store and update
+     *
+     * @var array $sharedRules
+     */
+    protected $sharedRules = [];
+
+    /**
+     * Rules that are specific to the store request
+     *
+     * They will overwrite the rule set in $sharedRules
+     *
+     * @var array $storeRules
+     */
+    protected $storeRules = [];
+
+    /**
+     * Rules that are specific to the update request
+     *
+     * They will overwrite the rule set in $sharedRules
+     *
+     * @var array $updateRules
+     */
+    protected $updateRules = [];
+
+    /**
+     * ApiController constructor.
+     */
+    public function __construct()
+    {
+        $this->repository = resolve($this->repository());
+        $this->resource = $this->resource();
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public function all()
+    {
+        return $this->resource::collection(
+            $this->repository->all()
+        );
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param $request
+     * @return JsonResource
+     */
+    public function store(Request $request)
+    {
+        $request->validate(
+            array_merge(
+                $this->sharedRules,
+                $this->storeRules
+            )
+        );
+
+        return new $this->resource($this->repository->create($request->all()));
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int $id
+     * @return JsonResource
+     */
+    public function show($id)
+    {
+        return new $this->resource($this->repository->findById($id));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  $request
+     * @param  int $id
+     * @return JsonResource
+     */
+    public function update(Request $request, $id)
+    {
+        $request->validate(
+            array_merge(
+                $this->sharedRules,
+                $this->updateRules
+            )
+        );
+
+        $this->repository->update($id, $request->all());
+
+        return new $this->resource($this->repository->findById($id));
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        $this->repository->delete($id);
+
+        return response(['success' => true], 200);
+    }
+}

--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -8,10 +8,11 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 abstract class ApiController extends Controller
 {
+
     /**
-     * @var $repository
+     * @var string $repository
      */
-    protected $repository;
+    private $repository;
 
     /**
      * Should return the <RepositoryInterface>::class
@@ -21,9 +22,9 @@ abstract class ApiController extends Controller
     abstract public function repository();
 
     /**
-     * @var $resource
+     * @var string $resource
      */
-    protected $resource;
+    private $resource;
 
     /**
      * Should return the <Resource>::class
@@ -33,29 +34,18 @@ abstract class ApiController extends Controller
     abstract public function resource();
 
     /**
-     * These rules are shared between both store and update
+     * Should return <StoreRequest>::class
      *
-     * @var array $sharedRules
+     * @return string
      */
-    protected $sharedRules = [];
+    abstract public function storeRequest();
 
     /**
-     * Rules that are specific to the store request
+     * Should return <UpdateRequest>::class
      *
-     * They will overwrite the rule set in $sharedRules
-     *
-     * @var array $storeRules
+     * @return string
      */
-    protected $storeRules = [];
-
-    /**
-     * Rules that are specific to the update request
-     *
-     * They will overwrite the rule set in $sharedRules
-     *
-     * @var array $updateRules
-     */
-    protected $updateRules = [];
+    abstract public function updateRequest();
 
     /**
      * ApiController constructor.
@@ -81,17 +71,12 @@ abstract class ApiController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param $request
+     * @param Request $request
      * @return JsonResource
      */
     public function store(Request $request)
     {
-        $request->validate(
-            array_merge(
-                $this->sharedRules,
-                $this->storeRules
-            )
-        );
+        resolve($this->storeRequest());
 
         return new $this->resource($this->repository->create($request->all()));
     }
@@ -110,18 +95,13 @@ abstract class ApiController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  $request
+     * @param  Request $request
      * @param  int $id
      * @return JsonResource
      */
     public function update(Request $request, $id)
     {
-        $request->validate(
-            array_merge(
-                $this->sharedRules,
-                $this->updateRules
-            )
-        );
+        resolve($this->updateRequest());
 
         $this->repository->update($id, $request->all());
 

--- a/app/Http/Controllers/Api/ArtistController.php
+++ b/app/Http/Controllers/Api/ArtistController.php
@@ -3,38 +3,32 @@
 namespace App\Http\Controllers\Api;
 
 use App\Contracts\ArtistRepositoryInterface;
+use App\Http\Requests\StoreArtist;
+use App\Http\Requests\UpdateArtist;
 use App\Http\Resources\ArtistResource;
 
 class ArtistController extends ApiController
 {
 
     /**
-     * @var array $sharedRules
+     * Sets the StoreRequest to resolve for validation during a store request
+     *
+     * @return string
      */
-    protected $sharedRules = [
-        'moniker' => 'max:255',
-        'alt_moniker' => 'max:255',
-        'email' => 'email',
-        'city' => 'max:255',
-        'territory' => 'max:255',
-        'country_code' => 'exists:countries,code',
-        'official_url' => 'url',
-        'profile_url' => 'max:64', // TODO This requires further validation, to prevent tomfoolery, profanity, etc..
-    ];
+    public function storeRequest()
+    {
+        return StoreArtist::class;
+    }
 
     /**
-     * @var array $storeRules
+     * Sets the UpdateRequest to resolve for validation during a update request
+     *
+     * @return string
      */
-    protected $storeRules = [
-        'moniker' => 'required|max:255',
-    ];
-
-    /**
-     * @var array $updateRules
-     */
-    protected $updateRules = [
-        'moniker' => 'required|max:255', // TODO: should this really be required ? Per the tests it fails otherwise ...
-    ];
+    public function updateRequest()
+    {
+        return UpdateArtist::class;
+    }
 
     /**
      * Sets the RepositoryInterface to resolve

--- a/app/Http/Controllers/Api/ArtistController.php
+++ b/app/Http/Controllers/Api/ArtistController.php
@@ -3,86 +3,56 @@
 namespace App\Http\Controllers\Api;
 
 use App\Contracts\ArtistRepositoryInterface;
-use App\Http\Requests\StoreArtist;
 use App\Http\Resources\ArtistResource;
-use App\Http\Controllers\Controller;
 
-class ArtistController extends Controller
+class ArtistController extends ApiController
 {
 
     /**
-     * @var ArtistRepositoryInterface
+     * @var array $sharedRules
      */
-    protected $artist;
+    protected $sharedRules = [
+        'moniker' => 'max:255',
+        'alt_moniker' => 'max:255',
+        'email' => 'email',
+        'city' => 'max:255',
+        'territory' => 'max:255',
+        'country_code' => 'exists:countries,code',
+        'official_url' => 'url',
+        'profile_url' => 'max:64', // TODO This requires further validation, to prevent tomfoolery, profanity, etc..
+    ];
 
     /**
-     * ArtistController constructor.
-     *
-     * @param ArtistRepositoryInterface $artist
+     * @var array $storeRules
      */
-    public function __construct(ArtistRepositoryInterface $artist)
+    protected $storeRules = [
+        'moniker' => 'required|max:255',
+    ];
+
+    /**
+     * @var array $updateRules
+     */
+    protected $updateRules = [
+        'moniker' => 'required|max:255', // TODO: should this really be required ? Per the tests it fails otherwise ...
+    ];
+
+    /**
+     * Sets the RepositoryInterface to resolve
+     *
+     * @return string
+     */
+    public function repository()
     {
-        $this->artist = $artist;
+        return ArtistRepositoryInterface::class;
     }
 
     /**
-     * Display a listing of the resource.
+     * Sets the ModelResource to resolve
      *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     * @return string
      */
-    public function all()
+    public function resource()
     {
-        return ArtistResource::collection(
-            $this->artist->all()
-        );
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \App\Http\Requests\StoreArtist $request
-     * @return ArtistResource
-     */
-    public function store(StoreArtist $request)
-    {
-        return new ArtistResource($this->artist->create($request->all()));
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param  int $id
-     * @return ArtistResource
-     */
-    public function show($id)
-    {
-        return new ArtistResource($this->artist->findById($id));
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \App\Http\Requests\StoreArtist $request
-     * @param  int $id
-     * @return ArtistResource
-     */
-    public function update(StoreArtist $request, $id)
-    {
-        $this->artist->update($id, $request->all());
-
-        return new ArtistResource($this->artist->findById($id));
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  int $id
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy($id)
-    {
-        $this->artist->delete($id);
-
-        return response(['success' => true], 200);
+        return ArtistResource::class;
     }
 }

--- a/app/Http/Requests/UpdateArtist.php
+++ b/app/Http/Requests/UpdateArtist.php
@@ -24,7 +24,6 @@ class UpdateArtist extends FormRequest
     public function rules()
     {
         return [
-            'moniker' => 'required|max:255', // TODO: removing `required` from this causes tests to fail ?
             'alt_moniker' => 'max:255',
             'email' => 'email',
             'city' => 'max:255',

--- a/app/Http/Requests/UpdateArtist.php
+++ b/app/Http/Requests/UpdateArtist.php
@@ -24,6 +24,7 @@ class UpdateArtist extends FormRequest
     public function rules()
     {
         return [
+            'moniker' => 'max:255',
             'alt_moniker' => 'max:255',
             'email' => 'email',
             'city' => 'max:255',

--- a/app/Http/Requests/UpdateArtist.php
+++ b/app/Http/Requests/UpdateArtist.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateArtist extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'moniker' => 'required|max:255', // TODO: removing `required` from this causes tests to fail ?
+            'alt_moniker' => 'max:255',
+            'email' => 'email',
+            'city' => 'max:255',
+            'territory' => 'max:255',
+            'country_code' => 'exists:countries,code',
+            'official_url' => 'url',
+            'profile_url' => 'max:64', // TODO This requires further validation, to prevent tomfoolery, profanity, etc..
+        ];
+    }
+}

--- a/app/Http/Resources/ProfileResource.php
+++ b/app/Http/Resources/ProfileResource.php
@@ -17,6 +17,7 @@ class ProfileResource extends JsonResource
         return [
             'moniker' => $this->moniker,
             'alt_moniker' => $this->alt_moniker,
+            'email' => $this->email,
             'city' => $this->city,
             'territory' => $this->territory,
             'country_code' => $this->country_code,

--- a/resources/stubs/apicontroller.stub
+++ b/resources/stubs/apicontroller.stub
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+class DummyClass extends ApiController
+{
+
+    /**
+     * Sets the StoreRequest to resolve for validation during a store request
+     *
+     * @return string
+     */
+    public function storeRequest()
+    {
+        // return StoreRequest::class;
+    }
+
+    /**
+     * Sets the UpdateRequest to resolve for validation during a update request
+     *
+     * @return string
+     */
+    public function updateRequest()
+    {
+        // return UpdateRequest::class;
+    }
+
+    /**
+     * Sets the RepositoryInterface to resolve
+     *
+     * @return string
+     */
+    public function repository()
+    {
+        // return ModelRepositoryInterface::class;
+    }
+
+    /**
+     * Sets the ModelResource to resolve
+     *
+     * @return string
+     */
+    public function resource()
+    {
+        // return ModelResource::class;
+    }
+}

--- a/tests/Feature/Controllers/ArtistControllerTest.php
+++ b/tests/Feature/Controllers/ArtistControllerTest.php
@@ -82,6 +82,7 @@ class ArtistControllerTest extends ControllerTestCase
     public function getInputsInInvalidState()
     {
         return [
+            'moniker' => str_random(256),
             'alt_moniker' => str_random(256),
             'email' => 'foo@',
             'city' => str_random(256),

--- a/tests/Feature/Controllers/ArtistControllerTest.php
+++ b/tests/Feature/Controllers/ArtistControllerTest.php
@@ -7,9 +7,21 @@ use CountriesSeeder;
 use App\Contracts\CountryRepositoryInterface;
 use App\Contracts\ArtistRepositoryInterface;
 use App\Contracts\ProfileRepositoryInterface;
+use App\Http\Requests\StoreArtist;
+use App\Http\Requests\UpdateArtist;
 
 class ArtistControllerTest extends ControllerTestCase
 {
+    /**
+     * @var StoreArtist
+     */
+    protected $storeArtist;
+
+    /**
+     * @var UpdateArtist
+     */
+    protected $updateArtist;
+
     public function setUp()
     {
         parent::setUp();
@@ -19,6 +31,13 @@ class ArtistControllerTest extends ControllerTestCase
         $this->country = resolve(CountryRepositoryInterface::class);
         $this->artist = resolve(ArtistRepositoryInterface::class);
         $this->profile = resolve(ProfileRepositoryInterface::class);
+
+        // New-up the Form Request classes directly, only so we can get the
+        // validation rules from them dynamically.
+
+        $this->storeArtist = new StoreArtist();
+
+        $this->updateArtist = new UpdateArtist();
     }
 
     public function spawnArtist()
@@ -51,6 +70,7 @@ class ArtistControllerTest extends ControllerTestCase
         return [
             'moniker' => 'Joey\'s Basement Band',
             'alt_moniker' => 'No Longer in the Garage',
+            'email' => 'foo@bar.com',
             'city' => 'New York City',
             'territory' => 'New York',
             'country_code' => 'US',
@@ -63,6 +83,7 @@ class ArtistControllerTest extends ControllerTestCase
     {
         return [
             'alt_moniker' => str_random(256),
+            'email' => 'foo@',
             'city' => str_random(256),
             'territory' => str_random(256),
             'country_code' => 'United States',
@@ -99,7 +120,7 @@ class ArtistControllerTest extends ControllerTestCase
             ->assertStatus(422)
             ->assertJsonStructure([
                 'message',
-                'errors' => array_keys($this->getAllInputsInValidState())
+                'errors' => array_keys($this->storeArtist->rules())
             ]);
     }
 
@@ -143,7 +164,7 @@ class ArtistControllerTest extends ControllerTestCase
             ->assertStatus(422)
             ->assertJsonStructure([
                 'message',
-                'errors' => array_keys($this->getAllInputsInValidState())
+                'errors' => array_keys($this->updateArtist->rules())
             ]);
     }
 }


### PR DESCRIPTION
This proposes that we add this abstract controller do reduce the code
duplication. Create new controllers on the fly by setting a few values
and moving on with life.

In addition, We could also extend the `make:controller` Artisan command to include something like .. `make:controller --api` and using a stub file that will generate these controllers.

Maybe the Artisan command should be included in this PR ?