### PR TITLE
Moved stub methods around

### DIFF
--- a/resources/stubs/apicontroller.stub
+++ b/resources/stubs/apicontroller.stub
@@ -6,26 +6,6 @@ class DummyClass extends ApiController
 {
 
     /**
-     * Sets the StoreRequest to resolve for validation during a store request
-     *
-     * @return string
-     */
-    public function storeRequest()
-    {
-        // return StoreRequest::class;
-    }
-
-    /**
-     * Sets the UpdateRequest to resolve for validation during a update request
-     *
-     * @return string
-     */
-    public function updateRequest()
-    {
-        // return UpdateRequest::class;
-    }
-
-    /**
      * Sets the RepositoryInterface to resolve
      *
      * @return string
@@ -43,5 +23,25 @@ class DummyClass extends ApiController
     public function resource()
     {
         // return ModelResource::class;
+    }
+
+    /**
+     * Sets the StoreRequest to resolve for validation during a store request
+     *
+     * @return string
+     */
+    public function storeRequest()
+    {
+        // return StoreRequest::class;
+    }
+
+    /**
+     * Sets the UpdateRequest to resolve for validation during a update request
+     *
+     * @return string
+     */
+    public function updateRequest()
+    {
+        // return UpdateRequest::class;
     }
 }


### PR DESCRIPTION
The way I see it is that the `repository` and `resource` take priority