### PR TITLE
ci: Remove build ignore rule for wip-* branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 env:
   - DISCORD_WEBHOOK="https://discordapp.com/api/webhooks/480159786286186546/AB1KcL2wz94yP3ZRVwVploKFk7ewaOn6evD6tVGQ8ywyWsMjVOXDfA0QZF2qaP7-ap9g"
 
-branches:
-  except:
-  - /^(?i:wip)-.*$/
-
 language: php
 
 php:


### PR DESCRIPTION
After some discussion, the project maintainers have decided that it
would be simpler to disable "Build pushed branches" in the TravisCI
configuration, as TravisCI builds are really only necessary for PRs,
given that PRs are the exclusive means by which changes are pushed
to the master branch.