### PR TITLE
Update BaseRepository findById method

### DIFF
--- a/app/Repositories/BaseRepository.php
+++ b/app/Repositories/BaseRepository.php
@@ -21,7 +21,7 @@ abstract class BaseRepository implements RepositoryShouldRead
 
     public function findById($id)
     {
-        return $this->model()->find($id);
+        return $this->model()->findOrFail($id);
     }
 
     public function delete($id)


### PR DESCRIPTION
This should throw an exception if the model is not found. In practice we
should be handling this exception gracefully.