### PR TITLE
tests: Update deletion test to be consistent with other recent fixes

### DIFF
--- a/tests/Feature/Repositories/RepositoryCrudTestCase.php
+++ b/tests/Feature/Repositories/RepositoryCrudTestCase.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Repositories;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
 abstract class RepositoryCrudTestCase extends RepositoryReadOnlyTestCase
 {
     /**
@@ -36,6 +38,10 @@ abstract class RepositoryCrudTestCase extends RepositoryReadOnlyTestCase
 
         $model->delete();
 
-        $this->assertNull($this->repo->findById($model->id));
+        try {
+            $this->repo->findById($model->id);
+        } catch(ModelNotFoundException $e) {
+            $this->assertTrue(true);
+        }
     }
 }


### PR DESCRIPTION
We've done this elsewhere and I figured it made sense to implement the same here.