### PR TITLE
Fix Api Routes With Tests

### DIFF
--- a/app/Providers/ApiRouteServiceProvider.php
+++ b/app/Providers/ApiRouteServiceProvider.php
@@ -45,7 +45,7 @@ class ApiRouteServiceProvider extends ServiceProvider
         // ...
     }
 
-    private function mapRoutes($prefix, $controller)
+    protected function mapRoutes($prefix, $controller)
     {
         return new ApiRoute($prefix, $controller);
     }

--- a/app/Providers/ApiRouteServiceProvider.php
+++ b/app/Providers/ApiRouteServiceProvider.php
@@ -47,8 +47,6 @@ class ApiRouteServiceProvider extends ServiceProvider
 
     private function mapRoutes($prefix, $controller)
     {
-        $dto = new ApiRoute($prefix, $controller);
-        $dto->mapDefaultRoutes();
-        return $dto;
+        return new ApiRoute($prefix, $controller);
     }
 }

--- a/app/Services/ApiRoute.php
+++ b/app/Services/ApiRoute.php
@@ -26,6 +26,8 @@ class ApiRoute
     {
         $this->prefix = $prefix;
         $this->controller = $controller;
+
+        $this->mapDefaultRoutes();
     }
 
     public function mapDefaultRoutes()
@@ -51,13 +53,31 @@ class ApiRoute
 
     public function mapAdditionalRoute($uri, $controllerMethod, $httpMethod = 'get')
     {
+        $controller = $this->controller;
+        $prefix = $this->prefix;
         $httpMethod = strtolower($httpMethod);
         $controllerMethod = snake_case($controllerMethod);
 
-        $controller = $this->controller;
-        $prefix = $this->prefix;
-
-        Route::$httpMethod($uri, "$controller@$controllerMethod")->name("$prefix.$controllerMethod");
+        Route::prefix('api')
+            ->middleware('api')
+            ->namespace($this->namespace)
+            ->group(function () use (
+                $controller,
+                $prefix,
+                $uri,
+                $controllerMethod,
+                $httpMethod
+            ) {
+                Route::prefix($this->prefix)->group(function () use (
+                    $controller,
+                    $prefix,
+                    $uri,
+                    $controllerMethod,
+                    $httpMethod
+                ) {
+                    Route::$httpMethod($uri, "$controller@$controllerMethod")->name("$prefix.$controllerMethod");
+                });
+            });
 
         return $this;
     }

--- a/app/Services/ApiRoute.php
+++ b/app/Services/ApiRoute.php
@@ -30,7 +30,7 @@ class ApiRoute
         $this->mapDefaultRoutes();
     }
 
-    public function mapDefaultRoutes()
+    protected function mapDefaultRoutes()
     {
         $controller = $this->controller;
         $prefix = $this->prefix;

--- a/tests/Feature/Services/ApiRouteTest.php
+++ b/tests/Feature/Services/ApiRouteTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Providers\RouteServiceProvider;
+use App\Services\ApiRoute;
+use Illuminate\Routing\Router;
+use Tests\TestCase;
+
+class ApiRouteTest extends TestCase
+{
+
+    protected $methods = [
+        'index' => 'get',
+        'show' => 'get',
+        'store' => 'post',
+        'update' => 'put',
+        'destroy' => 'delete',
+
+        'whatever' => 'get',
+        'another' => 'post'
+    ];
+
+    /**
+     * @var ApiRoute $service
+     */
+    protected $service;
+
+    /**
+     * @var Router $router
+     */
+    protected $router;
+
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->service = new MockApiRouteServiceProvider($this->app);
+        $this->service->boot();
+
+        $this->router = resolve(Router::class);
+
+    }
+
+    public function test_router_can_be_constructed()
+    {
+        $this->assertInstanceOf(Router::class, $this->router);
+    }
+
+    public function test_it_created_routes()
+    {
+        $methods = array_keys($this->methods);
+
+        foreach ($methods as $method) {
+            $this->assertNotNull(
+                $this->router
+                    ->getRoutes()
+                    ->getByName("tests.$method")
+            );
+        }
+    }
+
+    public function test_routes_have_proper_httpMethods()
+    {
+        $methods = $this->methods;
+
+        foreach ($methods as $method => $httpMethod) {
+            $this->assertTrue(
+                $this->has_httpMethod("tests.$method", $httpMethod),
+                "Invalid http method for $method! Expected $httpMethod"
+            );
+        }
+    }
+
+    public function test_routes_have_api_prefix()
+    {
+        $methods = array_keys($this->methods);
+
+        foreach ($methods as $method) {
+            $this->assertTrue($this->has_prefix("tests.$method"));
+        }
+    }
+
+    public function test_routes_have_api_middleware()
+    {
+        $methods = array_keys($this->methods);
+
+        foreach ($methods as $method) {
+            $this->assertTrue($this->has_middleware("tests.$method"));
+        }
+    }
+
+    public function test_routes_have_api_namespace()
+    {
+        $methods = array_keys($this->methods);
+
+        foreach ($methods as $method) {
+            $this->assertTrue($this->has_namespace("tests.$method"));
+        }
+    }
+
+    protected function has_httpMethod($route, $httpMethod)
+    {
+        $httpMethod = strtoupper($httpMethod);
+
+        return in_array($httpMethod,
+            $this->router
+                ->getRoutes()
+                ->getByName($route)
+                ->methods()
+        );
+    }
+
+    protected function has_prefix($route, $prefix = 'api')
+    {
+        return starts_with(
+            $this->router
+                ->getRoutes()
+                ->getByName($route)
+                ->uri(),
+            $prefix
+        );
+    }
+
+    protected function has_middleware($route, $middleware = 'api')
+    {
+        return in_array($middleware,
+            $this->router
+                ->getRoutes()
+                ->getByName($route)
+                ->middleware()
+        );
+    }
+
+    protected function has_namespace($route, $namespace = 'App\Http\Controllers\Api')
+    {
+        return (
+            $namespace === $this->router
+                ->getRoutes()
+                ->getByName($route)->action['namespace']
+        );
+    }
+
+}
+
+class MockApiRouteServiceProvider extends RouteServiceProvider
+{
+    public function boot()
+    {
+        parent::boot();
+    }
+
+    public function map()
+    {
+        $this->mapRoutes('tests', 'TestController')
+            ->mapAdditionalRoute('/whatever', 'whatever')
+            ->mapAdditionalRoute('/another', 'another', 'post');
+    }
+
+    public function mapRoutes($prefix, $controller)
+    {
+        return new ApiRoute($prefix, $controller);
+    }
+}


### PR DESCRIPTION
This PR addresses issue #97 

The issue was that additional routes were not getting registered correctly and this was able to slide in due to no tests.

Tests have been added!