### PR TITLE
docs: Fix trivial discrepancy with upstream license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -633,8 +633,8 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
The document should be identical to the version at
https://www.gnu.org/licenses/agpl-3.0.txt , which this commit ensures.

Ref: Unresolved review comments at https://github.com/indiehd/web-api/pull/121