### PR TITLE
Add feature to exclude routes from default routes

### DIFF
--- a/app/Providers/ApiRouteServiceProvider.php
+++ b/app/Providers/ApiRouteServiceProvider.php
@@ -36,14 +36,14 @@ class ApiRouteServiceProvider extends ServiceProvider
      */
     public function map()
     {
-        $this->mapRoutes('users', 'UserController');
-        $this->mapRoutes('artists', 'ArtistController');
-        $this->mapRoutes('albums', 'AlbumController');
-        $this->mapRoutes('songs', 'SongController');
+        $this->apiRoute('users', 'UserController')->addDefaultRoutes();
+        $this->apiRoute('artists', 'ArtistController')->addDefaultRoutes();
+        $this->apiRoute('albums', 'AlbumController')->addDefaultRoutes();
+        $this->apiRoute('songs', 'SongController')->addDefaultRoutes();
         // ...
     }
 
-    protected function mapRoutes($prefix, $controller)
+    protected function apiRoute($prefix, $controller)
     {
         return new ApiRoute($prefix, $controller);
     }

--- a/app/Services/ApiRoute.php
+++ b/app/Services/ApiRoute.php
@@ -21,42 +21,80 @@ class ApiRoute
      */
     private $controller;
 
+    /**
+     * @var array $routes
+     */
+    private $routes = [
+        'index' => [
+            'uri' => '/',
+            'httpMethod' => 'get',
+            'action' => 'all'
+        ],
+        'show' => [
+            'uri' => '/{id}',
+            'httpMethod' => 'get',
+            'action' => 'show'
+        ],
+        'store' => [
+            'uri' => '/create',
+            'httpMethod' => 'post',
+            'action' => 'store'
+        ],
+        'update' => [
+            'uri' => '/{id}',
+            'httpMethod' => 'put',
+            'action' => 'update'
+        ],
+        'destroy' => [
+            'uri' => '/{id}',
+            'httpMethod' => 'delete',
+            'action' => 'destroy'
+        ],
+    ];
 
     public function __construct($prefix, $controller)
     {
         $this->prefix = $prefix;
         $this->controller = $controller;
-
-        $this->mapDefaultRoutes();
     }
 
-    protected function mapDefaultRoutes()
+    public function addDefaultRoutes()
     {
         $controller = $this->controller;
         $prefix = $this->prefix;
+        $routes = $this->routes;
 
         Route::prefix('api')
             ->middleware('api')
             ->namespace($this->namespace)
-            ->group(function () use ($controller, $prefix) {
-                Route::prefix($this->prefix)->group(function () use ($controller, $prefix) {
-                    Route::get('/', "$controller@all")->name("$prefix.index");
-                    Route::get('/{id}', "$controller@show")->name("$prefix.show");
-                    Route::post('/create', "$controller@store")->name("$prefix.store");
-                    Route::put('/{id}', "$controller@update")->name("$prefix.update");
-                    Route::delete('/{id}', "$controller@destroy")->name("$prefix.destroy");
+            ->group(function () use ($routes, $controller, $prefix) {
+                Route::prefix($prefix)->group(function () use ($routes, $controller, $prefix) {
+                    foreach ($routes as $key => $route) {
+                        $uri = $route['uri'];
+                        $httpMethod = $route['httpMethod'];
+                        $action = $route['action'];
+
+                        Route::$httpMethod($uri, "$controller@$action")->name("$prefix.$key");
+                    }
                 });
             });
 
         return $this;
     }
 
-    public function mapAdditionalRoute($uri, $controllerMethod, $httpMethod = 'get')
+    public function except(array $routes = [])
+    {
+        $this->routes = array_except($this->routes, $routes);
+        return $this;
+    }
+
+    public function addRoute($uri, $controllerMethod, $httpMethod = 'get', $name = null)
     {
         $controller = $this->controller;
         $prefix = $this->prefix;
         $httpMethod = strtolower($httpMethod);
         $controllerMethod = snake_case($controllerMethod);
+        $name = is_null($name) ? strtolower($controllerMethod) : strtolower($name);
 
         Route::prefix('api')
             ->middleware('api')
@@ -64,6 +102,7 @@ class ApiRoute
             ->group(function () use (
                 $controller,
                 $prefix,
+                $name,
                 $uri,
                 $controllerMethod,
                 $httpMethod
@@ -71,11 +110,12 @@ class ApiRoute
                 Route::prefix($this->prefix)->group(function () use (
                     $controller,
                     $prefix,
+                    $name,
                     $uri,
                     $controllerMethod,
                     $httpMethod
                 ) {
-                    Route::$httpMethod($uri, "$controller@$controllerMethod")->name("$prefix.$controllerMethod");
+                    Route::$httpMethod($uri, "$controller@$controllerMethod")->name("$prefix.$name");
                 });
             });
 

--- a/tests/Feature/Services/ApiRouteTest.php
+++ b/tests/Feature/Services/ApiRouteTest.php
@@ -61,6 +61,24 @@ class ApiRouteTest extends TestCase
         }
     }
 
+    public function testExceptMethodHasIndexRoute()
+    {
+        $this->assertNotNull(
+            $this->router
+                ->getRoutes()
+                ->getByName("excepts.index")
+        );
+    }
+
+    public function testExceptMethodExcludesUpdateRoute()
+    {
+        $this->assertNull(
+            $this->router
+                ->getRoutes()
+                ->getByName("excepts.update")
+        );
+    }
+
     public function test_routes_have_proper_httpMethods()
     {
         $methods = $this->methods;
@@ -153,12 +171,17 @@ class MockApiRouteServiceProvider extends RouteServiceProvider
 
     public function map()
     {
-        $this->mapRoutes('tests', 'TestController')
-            ->mapAdditionalRoute('/whatever', 'whatever')
-            ->mapAdditionalRoute('/another', 'another', 'post');
+        $this->apiRoute('tests', 'TestController')
+            ->addDefaultRoutes()
+            ->addRoute('/whatever', 'whatever')
+            ->addRoute('/another', 'another', 'post');
+
+        $this->apiRoute('excepts', 'ExceptsController')
+            ->except(['update'])
+            ->addDefaultRoutes();
     }
 
-    public function mapRoutes($prefix, $controller)
+    public function apiRoute($prefix, $controller)
     {
         return new ApiRoute($prefix, $controller);
     }


### PR DESCRIPTION
In some cases an Api route may not require a certain route to be created
along with the default routes. Now with a new method `except($route)` we
can exclude an array of routes from the default list BEFORE adding the
default routes.

This feature prompted the need for this API to be more scalable thus
causing API changes. With this new approach we shouldn't worry about
the API breaking in the future.

New API Examples:

```php
$this->apiRoute($prefix, $controller)
    ->except(array $routes)
    // routes to exclude: 'index', 'show', 'store', 'update', 'destroy'

    ->addDefaultRoutes()
    // add default routes: 'index', 'show', 'store', 'update', 'destroy'

    ->addRoute(
      $uri,
      $controllerMethod,
      $httpMethod = 'get',
      $name = null
    );
    // if $name is null, route name will become the lowercase version
    // of $controllerMethod
```