### PR TITLE
Feature: Limit and Paginate

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -70,16 +70,16 @@ abstract class ApiController extends Controller
             'limit' => 'numeric|min:1'
         ]);
 
-        $has_paginate = $request->has('paginate');
-        $has_limit = $request->has('limit');
+        $hasPaginate = $request->has('paginate');
+        $hasLimit = $request->has('limit');
 
-        if ($has_paginate && !$has_limit) {
+        if ($hasPaginate && !$hasLimit) {
             $models = $this->repository
                 ->paginate($request->get('paginate'));
-        } elseif ($has_limit && !$has_paginate) {
+        } elseif ($hasLimit && !$hasPaginate) {
             $models = $this->repository
                 ->limit($request->get('limit'));
-        } elseif ($has_paginate && $has_limit) {
+        } elseif ($hasPaginate && $hasLimit) {
             $models = $this->repository
                 ->limit(
                     $request->get('limit'),

--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -61,7 +61,7 @@ abstract class ApiController extends Controller
      *
      * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
      */
-    public function all()
+    public function index(Request $request)
     {
         return $this->resource::collection(
             $this->repository->all()

--- a/app/Repositories/BaseRepository.php
+++ b/app/Repositories/BaseRepository.php
@@ -2,19 +2,45 @@
 
 namespace App\Repositories;
 
+use Illuminate\Pagination\LengthAwarePaginator;
+
 abstract class BaseRepository
 {
     abstract public function model();
 
     /**
+     * @return mixed
+     */
+    public function all()
+    {
+        return $this->model()->all();
+    }
+
+    /**
+     * @param int $limit
      * @param int|null $paginate
      * @return mixed
      */
-    public function all(int $paginate = null)
+    public function limit(int $limit, int $paginate = null)
     {
-        return is_null($paginate)
-            ? $this->model()->all()
-            : $this->model()->paginate($paginate);
+        $results = $this->model()->limit($limit)->get();
+
+        if ($paginate) {
+            $page = LengthAwarePaginator::resolveCurrentPage();
+            $items = $results->slice(($page * $paginate) - $paginate, $paginate)->all();
+            return new LengthAwarePaginator($items, count($results), $paginate);
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param int $paginate
+     * @return mixed
+     */
+    public function paginate(int $paginate)
+    {
+        return $this->model()->paginate($paginate);
     }
 
     /**

--- a/app/Services/ApiRoute.php
+++ b/app/Services/ApiRoute.php
@@ -28,7 +28,7 @@ class ApiRoute
         'index' => [
             'uri' => '/',
             'httpMethod' => 'get',
-            'action' => 'all'
+            'action' => 'index'
         ],
         'show' => [
             'uri' => '/{id}',

--- a/tests/Feature/Controllers/ApiControllerTest.php
+++ b/tests/Feature/Controllers/ApiControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Controllers;
+
+use App\Contracts\UserRepositoryInterface;
+use CountriesSeeder;
+
+class ApiControllerTest extends ControllerTestCase
+{
+    protected $model;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(CountriesSeeder::class);
+
+        // To test the abstract ApiController we will use the User Model (as its the most likely to never change)
+        $this->model = resolve(UserRepositoryInterface::class);
+    }
+
+    private function paginatedJsonStructure()
+    {
+        return [
+            'data',
+            'links',
+            'meta'
+        ];
+    }
+
+    public function testApiControllerAllMethodReturnsAllModels()
+    {
+        factory($this->model->class(), 5)->create();
+
+        $this->json('GET', route('users.index'))
+            ->assertStatus(200)
+            ->assertJsonCount(5, 'data');
+    }
+
+    public function testApiControllerAllMethodReturnsOneOfFiveModels()
+    {
+        factory($this->model->class(), 5)->create();
+
+        $this->json('GET', route('users.index'), ['limit' => 1])
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function testApiControllerAllMethodReturnsPaginatedModels()
+    {
+        factory($this->model->class(), 10)->create();
+
+        $this->json('GET', route('users.index'), ['paginate' => 5])
+            ->assertStatus(200)
+            ->assertJsonStructure($this->paginatedJsonStructure())
+            ->assertJsonFragment(['per_page' => 5])
+            ->assertJsonCount(5, 'data');
+    }
+
+    public function testApiControllerAllMethodReturnsLimitedPaginatedModels()
+    {
+        factory($this->model->class(), 10)->create();
+
+        $this->json('GET', route('users.index'), [
+            'limit' => 8,
+            'paginate' => 2
+        ])
+            ->assertStatus(200)
+            ->assertJsonStructure($this->paginatedJsonStructure())
+            ->assertJsonFragment(['total' => 8, 'per_page' => 2])
+            ->assertJsonCount(2, 'data');
+    }
+
+}

--- a/tests/Feature/Controllers/ApiControllerTest.php
+++ b/tests/Feature/Controllers/ApiControllerTest.php
@@ -28,7 +28,7 @@ class ApiControllerTest extends ControllerTestCase
         ];
     }
 
-    public function testApiControllerAllMethodReturnsAllModels()
+    public function testApiControllerIndexMethodReturnsAllModels()
     {
         factory($this->model->class(), 5)->create();
 
@@ -37,7 +37,7 @@ class ApiControllerTest extends ControllerTestCase
             ->assertJsonCount(5, 'data');
     }
 
-    public function testApiControllerAllMethodReturnsOneOfFiveModels()
+    public function testApiControllerIndexMethodReturnsOneOfFiveModels()
     {
         factory($this->model->class(), 5)->create();
 
@@ -46,7 +46,7 @@ class ApiControllerTest extends ControllerTestCase
             ->assertJsonCount(1, 'data');
     }
 
-    public function testApiControllerAllMethodReturnsPaginatedModels()
+    public function testApiControllerIndexMethodReturnsPaginatedModels()
     {
         factory($this->model->class(), 10)->create();
 
@@ -57,7 +57,7 @@ class ApiControllerTest extends ControllerTestCase
             ->assertJsonCount(5, 'data');
     }
 
-    public function testApiControllerAllMethodReturnsLimitedPaginatedModels()
+    public function testApiControllerIndexMethodReturnsLimitedPaginatedModels()
     {
         factory($this->model->class(), 10)->create();
 

--- a/tests/Feature/Controllers/Routes/IndexRouteTest.php
+++ b/tests/Feature/Controllers/Routes/IndexRouteTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Tests\Feature\Controllers;
+namespace Tests\Feature\Controllers\Routes;
 
 use App\Contracts\UserRepositoryInterface;
+use Tests\Feature\Controllers\ControllerTestCase;
 use CountriesSeeder;
 
-class ApiControllerTest extends ControllerTestCase
+class IndexRouteTest extends ControllerTestCase
 {
     protected $model;
 
@@ -28,7 +29,7 @@ class ApiControllerTest extends ControllerTestCase
         ];
     }
 
-    public function testApiControllerIndexMethodReturnsAllModels()
+    public function testRouteReturnsAllResults()
     {
         factory($this->model->class(), 5)->create();
 
@@ -37,7 +38,7 @@ class ApiControllerTest extends ControllerTestCase
             ->assertJsonCount(5, 'data');
     }
 
-    public function testApiControllerIndexMethodReturnsOneOfFiveModels()
+    public function testRouteReturnsOneOfFiveResults()
     {
         factory($this->model->class(), 5)->create();
 
@@ -46,7 +47,7 @@ class ApiControllerTest extends ControllerTestCase
             ->assertJsonCount(1, 'data');
     }
 
-    public function testApiControllerIndexMethodReturnsPaginatedModels()
+    public function testRouteReturnsPaginatedResults()
     {
         factory($this->model->class(), 10)->create();
 
@@ -57,7 +58,7 @@ class ApiControllerTest extends ControllerTestCase
             ->assertJsonCount(5, 'data');
     }
 
-    public function testApiControllerIndexMethodReturnsLimitedPaginatedModels()
+    public function testRouteReturnsLimitedPaginatedResults()
     {
         factory($this->model->class(), 10)->create();
 
@@ -69,6 +70,25 @@ class ApiControllerTest extends ControllerTestCase
             ->assertJsonStructure($this->paginatedJsonStructure())
             ->assertJsonFragment(['total' => 8, 'per_page' => 2])
             ->assertJsonCount(2, 'data');
+    }
+
+    public function testRouteReturnsLimitedPaginatedResultsForPageTwo()
+    {
+        factory($this->model->class(), 10)->create();
+
+        $this->json('GET', route('users.index'), [
+            'limit' => 8,
+            'paginate' => 3,
+            'page' => 2
+        ])
+            ->assertStatus(200)
+            ->assertJsonStructure($this->paginatedJsonStructure())
+            ->assertJsonFragment([
+                'per_page' => 3,
+                'current_page' => 2,
+                'total' => 8
+            ])
+            ->assertJsonCount(3, 'data');
     }
 
 }


### PR DESCRIPTION
Example: `api/users?limit=10&paginate=2`

```json
{
  "data": [
    {
      "id": 1,
      "email": "jeremy95@example.com",
      "account": {
        "email": "ykoss@thiel.org",
        "first_name": null,
        "last_name": null,
        "address_one": null,
        "address_two": null,
        "city": null,
        "territory": null,
        "country_code": null,
        "country": null,
        "postal_code": null,
        "phone": null,
        "alt_phone": null
      },
      "permissions": null,
      "last_login": null
    },
    {
      "id": 2,
      "email": "dana48@example.com",
      "account": {
        "email": "lindsey.bechtelar@legros.com",
        "first_name": null,
        "last_name": null,
        "address_one": null,
        "address_two": null,
        "city": null,
        "territory": null,
        "country_code": null,
        "country": null,
        "postal_code": null,
        "phone": null,
        "alt_phone": null
      },
      "permissions": null,
      "last_login": null
    }
  ],
  "links": {
    "first": "\/?page=1",
    "last": "\/?page=5",
    "prev": null,
    "next": "\/?page=2"
  },
  "meta": {
    "current_page": 1,
    "from": 1,
    "last_page": 5,
    "path": "\/",
    "per_page": 2,
    "to": 2,
    "total": 10
  }
}
```