### PR TITLE
Use phpdbg to generate coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ services:
 
 script:
   - mkdir -p build/logs
-  - vendor/bin/phpunit tests --coverage-clover build/logs/clover.xml
+  - phpdbg -qrr vendor/bin/phpunit tests --coverage-clover build/logs/clover.xml
 
 after_success:
   - travis_retry php vendor/bin/php-coveralls -vvv


### PR DESCRIPTION
phpdbg is much faster than phpunit with regard to generating coverage
(at least 10x). This should speed-up Travis-CI builds significantly.