### PR TITLE
fix: Stop passing argument that has since been removed

### DIFF
--- a/tests/Feature/Controllers/AlbumControllerTest.php
+++ b/tests/Feature/Controllers/AlbumControllerTest.php
@@ -95,7 +95,7 @@ class AlbumControllerTest extends ControllerTestCase
             ->assertStatus(200)
             ->assertExactJson([
                 'data' => [
-                    $this->getJsonStructure($album, true)
+                    $this->getJsonStructure($album)
                 ]
             ]);
     }
@@ -107,7 +107,7 @@ class AlbumControllerTest extends ControllerTestCase
         $this->json('GET', route('albums.show', ['id' => $album->id]))
             ->assertStatus(200)
             ->assertExactJson([
-                'data' => $this->getJsonStructure($album, true)
+                'data' => $this->getJsonStructure($album)
             ]);
     }
 


### PR DESCRIPTION
@mblarsen I believe that we eliminated this argument in the referenced function, so I'm simply removing the unused boolean values that are still being passed.