### PR TITLE
style: Allow punctuation in subject

### DIFF
--- a/grumphp.yml
+++ b/grumphp.yml
@@ -5,7 +5,7 @@ parameters:
       allow_empty_message: false
       enforce_capitalized_subject: false
       enforce_no_subject_trailing_period: true
-      enforce_no_subject_punctuations: true
+      enforce_no_subject_punctuations: false
       enforce_single_lined_subject: true
       type_scope_conventions:
         - types:


### PR DESCRIPTION
Perfectly reasonable subjects are prevented with this rule in place. For example:

git commit -m "fix: prevent route `users.index`
Please omit all punctuations from commit message subject.