### PR TITLE
refactor: remove SubstituteBindings middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -41,7 +41,6 @@ class Kernel extends HttpKernel
 
         'api' => [
             'throttle:60,1',
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ];
 


### PR DESCRIPTION
Not in use since we exclusively use 'id's and not models