### PR TITLE
fix: Enforce uniqueness on Genre names and add approval fields

### DIFF
--- a/app/Genre.php
+++ b/app/Genre.php
@@ -8,6 +8,8 @@ class Genre extends Model
 {
     protected $guarded = ['id'];
 
+    protected $dates = ['approved_at'];
+
     public function albums()
     {
         return $this->belongsToMany(Album::class)

--- a/database/migrations/2018_01_13_201508_create_genres_table.php
+++ b/database/migrations/2018_01_13_201508_create_genres_table.php
@@ -15,7 +15,9 @@ class CreateGenresTable extends Migration
     {
         Schema::create('genres', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name');
+            $table->string('name')->unique();
+            $table->timestamp('approved_at')->nullable();
+            $table->unsignedBigInteger('approver_id')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2099_12_31_000000_add_all_foreign_keys.php
+++ b/database/migrations/2099_12_31_000000_add_all_foreign_keys.php
@@ -19,6 +19,10 @@ class AddAllForeignKeys extends Migration
             #$table->foreign('catalog_id')->references('id')->on('catalogs');
         });
 
+        Schema::table('genres', function (Blueprint $table) {
+            $table->foreign('approver_id', 'approver_id_fk')->references('id')->on('users');
+        });
+
         Schema::table('album_genre', function (Blueprint $table) {
             $table->foreign('album_id', 'album_id_fk')->references('id')->on('albums');
             $table->foreign('genre_id', 'genre_id_fk')->references('id')->on('genres');


### PR DESCRIPTION
The attendant business logic requires Genre names to be unique and that when a new Genre is added it is not yet approved.